### PR TITLE
Update trbunofficial.cls

### DIFF
--- a/trbunofficial.cls
+++ b/trbunofficial.cls
@@ -27,6 +27,7 @@
 \RequirePackage{textcomp}
 \RequirePackage[pagewise, mathlines]{lineno}
 \RequirePackage{geometry}
+\RequirePackage[realmainfile]{currfile}
 
 \RequirePackage[sort&compress, numbers]{natbib}
 \RequirePackage{xparse}
@@ -191,7 +192,7 @@
 		\hfill\break%
 		\hfill\break%
 		\if\@TotalWords 0
-		Word Count: \quickwordcount{trb_template}~words $+$ \total{table} table(s) $\times$ \@WordsPerTable\ $=$ \totalwordcount~words\\
+		Word Count: \quickwordcount{\currfilebase}~words $+$ \total{table} table(s) $\times$ \@WordsPerTable\ $=$ \totalwordcount~words\\
 		\else
 		Word Count: \@TotalWords\ words $+$ \total{table} table(s) $\times$ \@WordsPerTable\ $=$ \the\numexpr\@TotalWords + \totvalue{table}*\@WordsPerTable~words\\
 		\fi


### PR DESCRIPTION
used \currfilebase from package currfile with option realmainfile, so the count works regardless of the tex filename (not just trb_template). tested on overleaf and it worked.